### PR TITLE
Support Mapbox GL JS 2.5 and later

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -420,7 +420,7 @@ export default class AnimatedPopup extends Popup {
                     innerContainer.style.transform = transform;
 
                     // Set the transform-origin property based on the anchor position
-                    innerContainer.style.transformOrigin = getOriginFromClassList(innerContainer.classList);
+                    innerContainer.style.transformOrigin = this._anchor ? this._anchor.replace('-', ' ') : getOriginFromClassList(innerContainer.classList);
                 });
             };
         } else {


### PR DESCRIPTION
Mapbox GL JS 2.5 adds the `_anchor` property, and this plugin uses it if exists instead of calling `getOriginFromClassList`.

Fixes #2